### PR TITLE
dhtproxy: allow token refresh, set clientID

### DIFF
--- a/include/opendht/dht.h
+++ b/include/opendht/dht.h
@@ -71,11 +71,6 @@ public:
     Dht(int s, int s6, Config config);
     virtual ~Dht();
 
-
-#if OPENDHT_PROXY_CLIENT
-    void startProxy(const std::string&, const std::string&) {};
-#endif
-
     /**
      * Get the ID of the node.
      */

--- a/include/opendht/dht_interface.h
+++ b/include/opendht/dht_interface.h
@@ -29,7 +29,10 @@ public:
     virtual ~DhtInterface() = default;
 
 #if OPENDHT_PROXY_CLIENT
-    virtual void startProxy(const std::string& host, const std::string& deviceKey = "") = 0;
+    //virtual void startProxy() {};
+#if OPENDHT_PUSH_NOTIFICATIONS
+    virtual void setPushNotificationToken(const std::string& token) {};
+#endif
 #endif
 
     // [[deprecated]]

--- a/include/opendht/dht_proxy_client.h
+++ b/include/opendht/dht_proxy_client.h
@@ -46,13 +46,13 @@ public:
      * and an ID for the node.
      * @param serverHost the proxy address
      */
-    explicit DhtProxyClient(const std::string& serverHost);
-    /**
-     * Start the connection with a server.
-     * @param serverHost the server address
-     * @param deviceKey if we use push notifications
-     */
-    void startProxy(const std::string& serverHost, const std::string& deviceKey = "");
+    explicit DhtProxyClient(const std::string& serverHost, const std::string& pushClientId = "");
+
+#if OPENDHT_PUSH_NOTIFICATIONS
+    virtual void setPushNotificationToken(const std::string& token) {
+        deviceKey_ = token;
+    }
+#endif
 
     virtual ~DhtProxyClient();
 
@@ -248,6 +248,12 @@ public:
 
 private:
     const ValueType NO_VALUE;
+
+    /**
+     * Start the connection with a server.
+     */
+    void startProxy();
+
     /**
      * Get informations from the proxy node
      * @return the JSON returned by the proxy
@@ -266,6 +272,7 @@ private:
      */
     void cancelAllOperations();
     std::string serverHost_;
+    std::string pushClientId_;
     NodeStatus statusIpv4_ {NodeStatus::Disconnected};
     NodeStatus statusIpv6_ {NodeStatus::Disconnected};
 

--- a/include/opendht/dht_proxy_server.h
+++ b/include/opendht/dht_proxy_server.h
@@ -210,13 +210,14 @@ private:
 
 #if OPENDHT_PUSH_NOTIFICATIONS
     struct PushListener {
-        std::string key;
+        std::string pushToken;
         InfoHash hash;
         unsigned token;
         std::future<size_t> internalToken;
         std::chrono::steady_clock::time_point deadline;
         bool started {false};
         unsigned callbackId {0};
+        std::string clientId {};
         bool isAndroid {true};
     };
     mutable std::mutex lockPushListeners_;

--- a/include/opendht/dhtrunner.h
+++ b/include/opendht/dhtrunner.h
@@ -304,6 +304,7 @@ public:
         bool threaded;
 #if OPENDHT_PROXY_CLIENT
         std::string proxy_server;
+        std::string push_node_id;
 #endif //OPENDHT_PROXY_CLIENT
     };
 
@@ -313,11 +314,7 @@ public:
      * @param threaded: If false, ::loop() must be called periodically. Otherwise a thread is launched.
      * @param cb: Optional callback to receive general state information.
      */
-    void run(in_port_t port, const crypto::Identity identity, bool threaded = false, NetId network = 0
-#if OPENDHT_PROXY_CLIENT
-    , const std::string& proxy_server = "127.0.0.1:8000"
-#endif //OPENDHT_PROXY_CLIENT
-) {
+    void run(in_port_t port, const crypto::Identity identity, bool threaded = false, NetId network = 0) {
         run(port, {
             /*.dht_config = */{
                 /*.node_config = */{
@@ -330,7 +327,8 @@ public:
             },
             /*.threaded = */threaded,
 #if OPENDHT_PROXY_CLIENT
-            /*.proxy_server = */proxy_server
+            /*.proxy_server = */"",
+            /*.push_node_id = */""
 #endif //OPENDHT_PROXY_CLIENT
         });
     }
@@ -378,21 +376,29 @@ public:
     void join();
 
 #if OPENDHT_PROXY_CLIENT
-    void setProxyServer(const std::string& url = "127.0.0.1:8000") {
+    void setProxyServer(const std::string& url = "127.0.0.1:8000", const std::string& pushNodeId = "") {
         config_.proxy_server = url;
+        config_.push_node_id = pushNodeId;
     }
+
     /**
      * Start or stop the proxy
      * @param proxify if we want to use the proxy
      * @param deviceKey non empty to enable push notifications
      */
-    void enableProxy(bool proxify, const std::string& deviceKey = "");
+    void enableProxy(bool proxify);
+
 #endif // OPENDHT_PROXY_CLIENT
 #if OPENDHT_PROXY_SERVER
     void forwardAllMessages(bool forward);
 #endif // OPENDHT_PROXY_SERVER
 
 #if OPENDHT_PUSH_NOTIFICATIONS
+    /**
+     * Updates the push notification device token
+     */
+    void setPushNotificationToken(const std::string& token);
+
     /**
      * Insert a push notification to process for OpenDHT
      */
@@ -442,6 +448,10 @@ private:
      */
     std::unique_ptr<SecureDht> dht_via_proxy_;
     Config config_;
+
+#if OPENDHT_PUSH_NOTIFICATIONS
+    std::string pushToken_;
+#endif
 #endif // OPENDHT_PROXY_CLIENT
     /**
      * Store current listeners and translates global tokens for each client.

--- a/include/opendht/securedht.h
+++ b/include/opendht/securedht.h
@@ -294,9 +294,11 @@ public:
     }
 
 #if OPENDHT_PROXY_CLIENT
-    void startProxy(const std::string& host, const std::string& deviceKey = "") {
-        dht_->startProxy(host, deviceKey);
+#if OPENDHT_PUSH_NOTIFICATIONS
+    void setPushNotificationToken(const std::string& token = "") {
+        dht_->setPushNotificationToken(token);
     }
+#endif
 #endif
 
 #if OPENDHT_PROXY_SERVER

--- a/src/dhtrunner.cpp
+++ b/src/dhtrunner.cpp
@@ -89,8 +89,7 @@ DhtRunner::run(const SockAddr& local4, const SockAddr& local6, DhtRunner::Config
         rcv_thread.join();
     running = true;
 #if OPENDHT_PROXY_CLIENT
-    config_.dht_config = config.dht_config;
-    config_.threaded = config.threaded;
+    config_ = config;
 #endif //OPENDHT_PROXY_CLIENT
     doRun(local4, local6, config.dht_config);
     if (not config.threaded)
@@ -436,7 +435,7 @@ DhtRunner::doRun(const SockAddr& sin4, const SockAddr& sin6, SecureDht::Config c
 #if OPENDHT_PROXY_CLIENT
     if (!dht_via_proxy_) {
         auto dht_via_proxy = std::unique_ptr<DhtInterface>(
-            new DhtProxyClient(config_.proxy_server)
+            new DhtProxyClient(config_.proxy_server, config_.push_node_id)
         );
         dht_via_proxy_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht_via_proxy), config_.dht_config));
     }
@@ -861,16 +860,20 @@ DhtRunner::activeDht() const
 
 #if OPENDHT_PROXY_CLIENT
 void
-DhtRunner::enableProxy(bool proxify, const std::string& deviceKey) {
-    if (!dht_via_proxy_) {
-        auto dht_via_proxy = std::unique_ptr<DhtInterface>(
-            new DhtProxyClient(config_.proxy_server)
-        );
-        dht_via_proxy_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht_via_proxy), config_.dht_config));
+DhtRunner::enableProxy(bool proxify)
+{
+    if (dht_via_proxy_) {
+        dht_via_proxy_->shutdown({});
     }
     if (proxify) {
         // Init the proxy client
-        dht_via_proxy_->startProxy(config_.proxy_server, deviceKey);
+        auto dht_via_proxy = std::unique_ptr<DhtInterface>(
+            new DhtProxyClient(config_.proxy_server, config_.push_node_id)
+        );
+        dht_via_proxy_ = std::unique_ptr<SecureDht>(new SecureDht(std::move(dht_via_proxy), config_.dht_config));
+        if (not pushToken_.empty())
+            dht_via_proxy_->setPushNotificationToken(pushToken_);
+        //dht_via_proxy_->startProxy();
         // add current listeners
         for (auto& listener: listeners_) {
             auto tokenProxy = dht_via_proxy_->listen(listener->hash, listener->gcb, std::move(listener->f), std::move(listener->w));
@@ -881,9 +884,6 @@ DhtRunner::enableProxy(bool proxify, const std::string& deviceKey) {
     } else {
         use_proxy = proxify;
         loop_(); // Restart the classic DHT.
-        // We doesn't need to maintain the connection with the proxy.
-        // Delete it
-        dht_via_proxy_->shutdown({});
         // update all proxyToken for all proxyListener
         auto it = listeners_.begin();
         for (; it != listeners_.end(); ++it) {
@@ -899,6 +899,17 @@ DhtRunner::enableProxy(bool proxify, const std::string& deviceKey) {
         }
     }
 }
+
+/**
+ * Updates the push notification device token
+ */
+void
+DhtRunner::setPushNotificationToken(const std::string& token) {
+    pushToken_ = token;
+    if (dht_via_proxy_)
+        dht_via_proxy_->setPushNotificationToken(token);
+}
+
 #endif // OPENDHT_PROXY_CLIENT
 
 #if OPENDHT_PROXY_SERVER


### PR DESCRIPTION
* add method to set the push token independently from other configuration,
  since the push token can be updated during runtime.
* allow to provide a "clientID" to be sent in push notifications,
  used to demultiplex push notifications to multiple OpenDHT nodes running
  on the same host. For instance Ring uses the accountID as the clientID
  to know which account received the push notification.
* remove startProxy from Dht interface. Switching to a different server or changing the ClientID would require to instantiate a new ProxyClient to avoid broken states